### PR TITLE
Make piman server close with a single keyboard interrupt

### DIFF
--- a/ntpserver.py
+++ b/ntpserver.py
@@ -307,6 +307,7 @@ class WorkThread(threading.Thread):
 
 def do_ntp():
     print("NTP CODE IS RUNNING")
+    global stopFlag
     listenIp = "0.0.0.0"
     listenPort = 123
     ntpsocket = socket(AF_INET, SOCK_DGRAM)

--- a/piman.py
+++ b/piman.py
@@ -4,6 +4,7 @@ import os
 from zipfile import ZipFile
 import io
 import time
+import signal
 
 # create the logger before doing imports since everyone is going
 # to use them
@@ -97,11 +98,13 @@ def server():
     ntp_thread = Thread(target=ntpserver.do_ntp())
     ntp_thread.start()
 
-    config_ui_thread.join()
-    tftp_thread.join()
-    dhcp_thread.join()
-    tcp_thread.join()
-    ntp_thread.join()
+    signal.pthread_kill(config_ui_thread.ident, 15) # 15 = sigterm
+    signal.pthread_kill(tftp_thread.ident, 15)
+    signal.pthread_kill(dhcp_thread.ident, 15)
+    signal.pthread_kill(tcp_thread.ident, 15)
+    # ntp_thread does not need to be killed. ntpserver takes control of the terminal
+    # when it is run, so after it is closed by a keyboard interrupt, the above
+    # lines run closing the rest of the threads. ntp_thread will already be stopped
 
 
 def restart(switch_address, interface, ports):


### PR DESCRIPTION
After starting all the background threads, the ntpserver takes control of the terminal. This edit fixes a bug in ntpserver.py causing the keyboard interrupt to not be handled correctly, and then adds code to send a sigterm signal to the other background threads (config_ui, dhcp, tftp, & tcp). 

Previously, even with the bug in ntpserver.py fixed, the program would hang at <background thread>.join() until the user spammed Ctrl-c a few more times. Now a single Ctrl-c closes the program including all background threads.