### PR TITLE
Changes for piman.py and make_zipapp.sh. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,13 +139,13 @@ Functionalities include:
 
 * Running the piman server in the background
 ```bash
-sudo python3 piman.py server &
+sudo python3 piman.pyz server
 ```
-* Restarting a raspberry pi
+* Restarting a raspberry pi (restart multiple by listing more port numbers with spaces in-between) 
 ```bash
-sudo python3 piman.py restart <port number of a pi>
+sudo python3 piman.pyz restart <port number of a pi>
 ```
-* Reinstalling a raspberry pi
+* Reinstalling a raspberry pi (reinstall multiple by listing more port numbers with spaces in-between)
 ```bash
 sudo python3 piman.py reinstall <port number of a pi>
 ```
@@ -399,7 +399,11 @@ Navigate to `install/initram/README.md` to read about hello_protocol.sh.
 ---
 ### What is make_zipapp.sh?
 
-make_zipapp.sh is a script that will compress the entire repository into a /build directory.
+make_zipapp.sh is a script that will compress the entire repository into a /build directory. It should be run every time code changes have been made.
+WARNING: do not run with sudo privileges.
+'''bash
+./make_zipapp.sh
+'''
 
 ### Why make_zipapp.sh?
 

--- a/make_zipapp.sh
+++ b/make_zipapp.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [[ $UID -eq 0 ]]
+then 
+   echo "Do not run $0 as root"
+   exit 2
+fi
 rm -rf build
 mkdir build
 PYTHONUSERBASE=$PWD/build python3 -m pip install --ignore-installed click pysnmp Flask python-dotenv PyYAML


### PR DESCRIPTION
Documentation changes for piman.py: Fix the commands that are used to call the server and explain that multiple pis can be restarted in one command.
Documentation changes for make_zipapp.sh: Add the command and warn that sudo should not be used when calling make_zipapp.sh.
Code changes for make_zipapp.sh: Add code to warn the user that sudo has been used and exits the process.